### PR TITLE
非ログイン時のレイアウト修正

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,10 +1,10 @@
 class PostsController < ApplicationController
-  before_action :authenticate_user!
+  before_action :authenticate_user!, except: [:show]
 
   def show
     @post = Post.find(params[:id])
     @comments = @post.comments
-    @comment = current_user.comments.new
+    @comment = Comment.new
   end
 
   def new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,6 @@
 class UsersController < ApplicationController
+  before_action :authenticate_user!, except: [:show]
+
   def show
     @user = User.find(params[:id])
     @posts = Post.all

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -13,7 +13,7 @@
                 <hr>
                 <p class="card-text">参考URL: <%= @post.site_url %></p>
                 <hr>
-                <% if @post.user_id == current_user.id %>
+                <% if user_signed_in? && @post.user_id == current_user.id %>
                     <div class="text-center">
                         <%= link_to "編集", edit_post_path(@post), class: "btn btn-outline-success" %>
                         <%= link_to "削除", post_path(@post), method: :delete, data: {confirm: "削除しますか？"}, class: "btn btn-outline-danger" %>
@@ -32,12 +32,14 @@
                     </div>
                 <% end %>
 
-                <%= form_for [@post, @comment] do |f| %>
-                    <div class="form-group">
-                        <%= f.text_field :content, class: "form-control", id: "commentForm" %>
-                        <%= f.hidden_field :post_id, value: @post.id %>
-                    </div>
-                    <%= f.submit "コメントする", class: "btn btn-info mb-2" %>
+                <% if user_signed_in? %>
+                    <%= form_for [@post, @comment] do |f| %>
+                        <div class="form-group">
+                            <%= f.text_field :content, class: "form-control", id: "commentForm" %>
+                            <%= f.hidden_field :post_id, value: @post.id %>
+                        </div>
+                        <%= f.submit "コメントする", class: "btn btn-info mb-2" %>
+                    <% end %>
                 <% end %>
             </div>
         </div>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -14,7 +14,7 @@
                     </p>
                     <p class="text-center">
                         <%= link_to "もっとみる", post_path(post), class: "text-muted btn btn-outline-info" %>
-                        <% if post.user_id == current_user.id %>
+                        <% if user_signed_in? && post.user_id == current_user.id %>
                             <%= link_to "編集", edit_post_path(post), class: "btn btn-outline-success" %>
                             <%= link_to "削除", post_path(post), method: :delete, data: {confirm: "削除しますか？"}, class: "btn btn-outline-danger" %>
                         <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -28,7 +28,7 @@
                     </p>
                     <p class="text-center">
                         <%= link_to "もっとみる", post_path(post), class: "text-muted btn btn-outline-info" %>
-                        <% if post.user_id == current_user.id %>
+                        <% if user_signed_in? && post.user_id == current_user.id %>
                             <%= link_to "編集", edit_post_path(post), class: "btn btn-outline-success" %>
                             <%= link_to "削除", post_path(post), method: :delete, data: {confirm: "削除しますか？"}, class: "btn btn-outline-danger" %>
                         <% end %>


### PR DESCRIPTION
# 作業内容
・非ログイン時にはユーザー&記事詳細ページのみ表示する
・非ログイン時のエラー解消

# 所感
ログアウトしてからエラーが出ていることに気付いたので、記事投稿機能やユーザー作成機能のプルリクをmasterにマージする前に確認するべきだった。