### PR TITLE
記事詳細ページのエラー修正

### DIFF
--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -7,7 +7,7 @@
             <p class="d-block mx-auto"><%= image_tag @post.image.url unless @post.image.blank? %></p>
             <%= render 'posts/tag_list', tag_list: @post.tag_list %>
             <div class="card-body">
-                <%= render 'likes/like_form', post: @post %>
+                <%= render 'likes/like', post: @post %>
                 <p class="card-text">所在地: <%= @post.address %></p>
                 <hr>
                 <p class="card-text">施設説明:</p>


### PR DESCRIPTION
# 作業内容
・記事詳細ページのエラー修正

# 所感
・いいねボタンのファイル名を変更したことで発生していた、ユーザー詳細ページのエラーを解決した。