### PR TITLE
記事の星評価機能

### DIFF
--- a/app/assets/stylesheets/likes.scss
+++ b/app/assets/stylesheets/likes.scss
@@ -2,12 +2,12 @@
     font-size: 20px;
 
     i {
-        color: #FFD700;
+        color: #ffc0cb;
     }
 }
 
 .like-form  i {
-    color: #FFD700;
+    color: #ffc0cb;
 }
 
 .like-form  i,

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -80,7 +80,7 @@ class PostsController < ApplicationController
 
   # 記事投稿時に許可する属性
   def post_params
-    params.require(:post).permit(:title, :image, :remove_image, :address, :description, :site_url, :tag_list, :rate)
+    params.require(:post).permit(:title, :image, :remove_image, :address, :description, :site_url, :tag_list, :rate, :infection_control_rate)
   end
 
   # 権限のないページへのアクセス&編集を制限

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -80,7 +80,7 @@ class PostsController < ApplicationController
 
   # 記事投稿時に許可する属性
   def post_params
-    params.require(:post).permit(:title, :image, :remove_image, :address, :description, :site_url, :tag_list)
+    params.require(:post).permit(:title, :image, :remove_image, :address, :description, :site_url, :tag_list, :rate)
   end
 
   # 権限のないページへのアクセス&編集を制限

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -19,7 +19,7 @@ class Post < ApplicationRecord
   validates :infection_control_rate, numericality: {
     less_than_or_equal_to: 5,
     greater_than_or_equal_to: 1
-  }
+  }, if: Proc.new { |post| post.infection_control_rate.present? }
 
   def self.search(search)
     return Post.all unless search

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -16,6 +16,10 @@ class Post < ApplicationRecord
     less_than_or_equal_to: 5,
     greater_than_or_equal_to: 1
   }, presence: true
+  validates :infection_control_rate, numericality: {
+    less_than_or_equal_to: 5,
+    greater_than_or_equal_to: 1
+  }
 
   def self.search(search)
     return Post.all unless search

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -12,6 +12,10 @@ class Post < ApplicationRecord
   validates :address, length: { maximum: 200 }
   validates :description, presence: true, length: { maximum: 1200 }
   validates :site_url, length: { maximum: 200 }, format: /\A#{URI::regexp(%w(http https))}\z/
+  validates :rate, numericality: {
+    less_than_or_equal_to: 5,
+    greater_than_or_equal_to: 1
+  }, presence: true
 
   def self.search(search)
     return Post.all unless search

--- a/app/views/likes/_like.html.erb
+++ b/app/views/likes/_like.html.erb
@@ -2,14 +2,14 @@
     <% if user_signed_in? %>
         <% if current_user.already_liked?(post) %>
             <%= link_to post_like_path(post, Like.find_by(post_id: post.id, user_id: current_user.id)), method: :delete, remote: true do %>
-                <i class="fas fa-star"></i> <span class="text-muted"><%= post.likes.count %></span>
+                <i class="fas fa-heart"></i> <span class="text-muted"><%= post.likes.count %></span>
             <% end %>
         <% else %>
             <%= link_to post_likes_path(post.id), method: :post, remote: true do %>
-                <i class="far fa-star"></i> <span class="text-muted"><%= post.likes.count %></span>
+                <i class="far fa-heart"></i> <span class="text-muted"><%= post.likes.count %></span>
             <% end %>
         <% end %>
     <% else %>
-        <i class="fas fa-star"></i> <span class="text-muted"><%= post.likes.count %></span>
+        <i class="fas fa-heart"></i> <span class="text-muted"><%= post.likes.count %></span>
     <% end %>
 </div>

--- a/app/views/posts/_posts.html.erb
+++ b/app/views/posts/_posts.html.erb
@@ -12,6 +12,10 @@
                     <p class="card-text">おすすめ度: <%= "⭐️" * post.rate %></p>
                     <hr>
                 <% end %>
+                <% if post.infection_control_rate %>
+                    <p class="card-text">感染対策度: <%= "⭐️" * post.infection_control_rate %></p>
+                    <hr>
+                <% end %>
                 <%= render 'likes/like', post: post %>
             </p>
             <p class="text-center">

--- a/app/views/posts/_posts.html.erb
+++ b/app/views/posts/_posts.html.erb
@@ -8,6 +8,10 @@
         <div class="card-body">
             <p class="card-text">
             　  <%= post.description %>
+                <% if post.rate %>
+                    <p class="card-text">おすすめ度: <%= "⭐️" * post.rate %></p>
+                    <hr>
+                <% end %>
                 <%= render 'likes/like', post: post %>
             </p>
             <p class="text-center">

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -45,6 +45,11 @@
                     <%= f.text_field :rate, autofocus: true, autocomplete: "rate", class: "form-control" %>
                 </div>
 
+                <div class="form-group">
+                    <%= f.label :infection_control_rate %>　<span class="text-muted">*1~5で入力してください</span><br />
+                    <%= f.text_field :infection_control_rate, autofocus: true, autocomplete: "infection_control_rate", class: "form-control" %>
+                </div>
+
                 <div class="actions">
                     <%= f.submit "編集", class: "btn btn-info" %>
                 </div>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -40,6 +40,11 @@
                     <%= f.text_field :site_url, autofocus: true, autocomplete: "site_url", class: "form-control" %>
                 </div>
 
+                <div class="form-group">
+                    <%= f.label :rate %>　<span class="text-danger">*必須(1~5で入力してください)</span><br />
+                    <%= f.text_field :rate, autofocus: true, autocomplete: "rate", class: "form-control" %>
+                </div>
+
                 <div class="actions">
                     <%= f.submit "編集", class: "btn btn-info" %>
                 </div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -41,6 +41,11 @@
                     <%= f.text_field :rate, autofocus: true, autocomplete: "rate", class: "form-control" %>
                 </div>
 
+                <div class="form-group">
+                    <%= f.label :infection_control_rate %>　<span class="text-muted">*1~5で入力してください</span><br />
+                    <%= f.text_field :infection_control_rate, autofocus: true, autocomplete: "infection_control_rate", class: "form-control" %>
+                </div>
+
                 <div class="actions">
                     <%= f.submit "編集", class: "btn btn-info" %>
                 </div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -36,6 +36,11 @@
                     <%= f.text_field :site_url, autofocus: true, autocomplete: "site_url", class: "form-control" %>
                 </div>
 
+                <div class="form-group">
+                    <%= f.label :rate %>　<span class="text-danger">*必須(1~5で入力してください)</span><br />
+                    <%= f.text_field :rate, autofocus: true, autocomplete: "rate", class: "form-control" %>
+                </div>
+
                 <div class="actions">
                     <%= f.submit "編集", class: "btn btn-info" %>
                 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -15,6 +15,10 @@
                 <hr>
                 <p class="card-text">参考URL: <%= @post.site_url %></p>
                 <hr>
+                <% if @post.rate %>
+                    <p class="card-text">おすすめ度: <%= "⭐️" * @post.rate %></p>
+                    <hr>
+                <% end %>
                 <% if user_signed_in? && @post.user_id == current_user.id %>
                     <div class="text-center">
                         <%= link_to "編集", edit_post_path(@post), class: "btn btn-outline-success" %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -19,6 +19,10 @@
                     <p class="card-text">おすすめ度: <%= "⭐️" * @post.rate %></p>
                     <hr>
                 <% end %>
+                <% if @post.infection_control_rate %>
+                    <p class="card-text">感染対策度: <%= "⭐️" * @post.infection_control_rate %></p>
+                    <hr>
+                <% end %>
                 <% if user_signed_in? && @post.user_id == current_user.id %>
                     <div class="text-center">
                         <%= link_to "編集", edit_post_path(@post), class: "btn btn-outline-success" %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -22,6 +22,7 @@ ja:
         tag_list: タグ
         site_url: 参考URL
         rate: おすすめ度
+        infection_control_rate: 感染対策度
   date:
     abbr_day_names:
     - 日

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -21,6 +21,7 @@ ja:
         description: 施設説明
         tag_list: タグ
         site_url: 参考URL
+        rate: おすすめ度
   date:
     abbr_day_names:
     - 日

--- a/db/migrate/20210105005744_add_rate_to_post.rb
+++ b/db/migrate/20210105005744_add_rate_to_post.rb
@@ -1,0 +1,5 @@
+class AddRateToPost < ActiveRecord::Migration[5.2]
+  def change
+    add_column :posts, :rate, :float, null: false, default: 0
+  end
+end

--- a/db/migrate/20210105062801_add_infection_control_rate_to_post.rb
+++ b/db/migrate/20210105062801_add_infection_control_rate_to_post.rb
@@ -1,0 +1,5 @@
+class AddInfectionControlRateToPost < ActiveRecord::Migration[5.2]
+  def change
+    add_column :posts, :infection_control_rate, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_05_005744) do
+ActiveRecord::Schema.define(version: 2021_01_05_062801) do
 
   create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "content"
@@ -41,6 +41,7 @@ ActiveRecord::Schema.define(version: 2021_01_05_005744) do
     t.datetime "updated_at", null: false
     t.integer "user_id"
     t.float "rate", default: 0.0, null: false
+    t.float "infection_control_rate"
   end
 
   create_table "relationships", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_29_144321) do
+ActiveRecord::Schema.define(version: 2021_01_05_005744) do
 
   create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "content"
@@ -40,6 +40,7 @@ ActiveRecord::Schema.define(version: 2020_12_29_144321) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "user_id"
+    t.float "rate", default: 0.0, null: false
   end
 
   create_table "relationships", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|


### PR DESCRIPTION
# 作業内容
・施設のおすすめ度(必須)&感染対策度を登録できるようにする

# 所感
・当初jQueryのプラグインであるRatyを利用としたが少し苦戦したため、とりあえず1~5までの数値を入力することで星評価を表示できるようにした。
・Ratyは絶対必要というわけではないが、良い機会なので後で余裕が出来た時に導入してみようと思う。
