### PR TITLE
外部キーを持つデータを削除できるようにする

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,8 +2,8 @@ class Post < ApplicationRecord
   acts_as_taggable
 
   belongs_to :user
-  has_many :comments
-  has_many :likes
+  has_many :comments, dependent: :destroy
+  has_many :likes, dependent: :destroy
   has_many :liked_users, through: :likes, source: :user
 
   mount_uploader :image, ImageUploader

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,9 +1,9 @@
 class User < ApplicationRecord
   has_many :posts, dependent: :destroy
-  has_many :comments
+  has_many :comments, dependent: :destroy
   has_many :likes, dependent: :destroy
   has_many :liked_posts, through: :likes, source: :post
-  has_many :relationships
+  has_many :relationships, dependent: :destroy
   has_many :followings, through: :relationships, source: :follow
   has_many :reverse_of_relationships, class_name: 'Relationship', foreign_key: 'follow_id'
   has_many :followers, through: :reverse_of_relationships, source: :user


### PR DESCRIPTION
# 作業内容
・外部キーを持つデータをdestroyできるようにするために、紐づくデータも同時に削除する

# 所感
・記事とコメントが削除できなかったので修正。has_manyで関連付けしている場合は、基本的に「dependent: :destroy」をつける